### PR TITLE
MySQL 5.7 fixes

### DIFF
--- a/migrations/20160729154418-add-market-groups.js
+++ b/migrations/20160729154418-add-market-groups.js
@@ -15,7 +15,7 @@ exports.up = function(db, callback) {
 				'ALTER TABLE market_groups',
 				'ADD updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP',
 				'ON UPDATE CURRENT_TIMESTAMP,',
-				'ADD created_at timestamp NOT NULL'
+				'ADD created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP'
 			].join(' '),function (err) {
 				if (err) { callback(err);return }
 				db.connection.query([

--- a/migrations/20160729173143-add-inventory-types.js
+++ b/migrations/20160729173143-add-inventory-types.js
@@ -15,7 +15,7 @@ exports.up = function(db, callback) {
 				'ALTER TABLE inventory_types',
 				'ADD updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP',
 				'ON UPDATE CURRENT_TIMESTAMP,',
-				'ADD created_at timestamp NOT NULL'
+				'ADD created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP'
 			].join(' '),function (err) {
 				if (err) { callback(err);return }
 				db.connection.query([

--- a/migrations/20160729194058-add-inventory-groups.js
+++ b/migrations/20160729194058-add-inventory-groups.js
@@ -14,7 +14,7 @@ exports.up = function(db, callback) {
 				'ALTER TABLE inventory_groups',
 				'ADD updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP',
 				'ON UPDATE CURRENT_TIMESTAMP,',
-				'ADD created_at timestamp NOT NULL'
+				'ADD created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP'
 			].join(' '),function (err) {
 				if (err) { callback(err);return }
 				db.connection.query([

--- a/migrations/20160731080737-add-users.js
+++ b/migrations/20160731080737-add-users.js
@@ -20,7 +20,7 @@ exports.up = function(db, callback) {
 				'ALTER TABLE users',
 				'ADD updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP',
 				'ON UPDATE CURRENT_TIMESTAMP,',
-				'ADD created_at timestamp NOT NULL'
+				'ADD created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP'
 			].join(' '),function (err) {
 				if (err) { callback(err);return }
 				db.connection.query([

--- a/migrations/20160805004045-add-blueprints.js
+++ b/migrations/20160805004045-add-blueprints.js
@@ -15,7 +15,7 @@ exports.up = function(db, callback) {
 				'ALTER TABLE blueprints',
 				'ADD updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP',
 				'ON UPDATE CURRENT_TIMESTAMP,',
-				'ADD created_at timestamp NOT NULL'
+				'ADD created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP'
 			].join(' '),function (err) {
 				if (err) { callback(err);return }
 				db.connection.query([

--- a/models/InventoryGroups.js
+++ b/models/InventoryGroups.js
@@ -153,7 +153,7 @@ InventoryGroups.prototype.index = function (search,page,limit,respond) {
 		qry += ' WHERE (inventory_groups.name LIKE "%'+search+'%")'
 	}
 
-	qry += ' GROUP BY inventory_groups.name LIMIT ' + limit + ' OFFSET ' + offset
+	qry += ' LIMIT ' + limit + ' OFFSET ' + offset
 
 	pool.query(qry,function(err,rows) {
 		if (err) { console.log('InventoryGroups.prototype.all');console.log(err);respond('Failed to get all inventory_groups') }

--- a/models/InventoryTypes.js
+++ b/models/InventoryTypes.js
@@ -398,18 +398,19 @@ InventoryTypes.prototype.index = function (search,page,limit,respond) {
 	if (search) {
 		qry += ' WHERE (inventory_types.name LIKE "%'+search+'%" OR market_groups.name LIKE "%'+search+'%")'
 		qry += ' AND (inventory_types.id IN (' +
-		       'SELECT inventory_types.id FROM inventory_types LEFT JOIN market_groups ON market_groups.id = inventory_types.market_group_id ' +
+		       'SELECT MIN(inventory_types.id) FROM inventory_types LEFT JOIN market_groups ON market_groups.id = inventory_types.market_group_id ' +
 		       'WHERE (inventory_types.name LIKE "%'+search+'%" OR market_groups.name LIKE "%'+search+'%") ' +
 		       'GROUP BY inventory_types.name' +
 		       '))'
 	} else {
 		qry += ' WHERE inventory_types.id IN ('+
-		       'SELECT inventory_types.id FROM inventory_types LEFT JOIN market_groups ON market_groups.id = inventory_types.market_group_id ' +
+		       'SELECT MIN(inventory_types.id) FROM inventory_types LEFT JOIN market_groups ON market_groups.id = inventory_types.market_group_id ' +
 		       'GROUP BY inventory_types.name' +
 		       ')'
 	}
 
 	qry += ' LIMIT ' + limit + ' OFFSET ' + offset
+  console.log(qry)
 
 	pool.query(qry,function(err,rows) {
 		if (err) { console.log('InventoryTypes.prototype.all');console.log(err);respond('Failed to get all inventory_types') }
@@ -423,7 +424,7 @@ InventoryTypes.prototype.indexCount = function (search,respond) {
 	var qry =
 	'SELECT ' +
 
-	'COUNT(DISTINCT inventory_types.name) ' +
+	'COUNT(DISTINCT inventory_types.name) AS cnt ' +
 
 	'FROM inventory_types ' +
 	'LEFT JOIN market_groups ON market_groups.id = inventory_types.market_group_id'
@@ -431,11 +432,12 @@ InventoryTypes.prototype.indexCount = function (search,respond) {
 	if (search) {
 		qry += ' WHERE (inventory_types.name LIKE "%'+search+'%" OR market_groups.name LIKE "%'+search+'%")'
 	}
+  console.log(qry)
 
 	pool.query(qry,function(err,rows) {
 		if (err) { console.log('InventoryTypes.prototype.all');console.log(err);respond('Failed to get all inventory_types') }
 		else if (!rows.length) { respond(null,0) }
-		else { respond(null,rows[0]['COUNT(*)']) }
+		else { respond(null,rows[0]['cnt']) }
 	})
 }
 

--- a/models/InventoryTypes.js
+++ b/models/InventoryTypes.js
@@ -397,9 +397,19 @@ InventoryTypes.prototype.index = function (search,page,limit,respond) {
 
 	if (search) {
 		qry += ' WHERE (inventory_types.name LIKE "%'+search+'%" OR market_groups.name LIKE "%'+search+'%")'
+		qry += ' AND (inventory_types.id IN (' +
+		       'SELECT inventory_types.id FROM inventory_types LEFT JOIN market_groups ON market_groups.id = inventory_types.market_group_id ' +
+		       'WHERE (inventory_types.name LIKE "%'+search+'%" OR market_groups.name LIKE "%'+search+'%") ' +
+		       'GROUP BY inventory_types.name' +
+		       '))'
+	} else {
+		qry += ' WHERE inventory_types.id IN ('+
+		       'SELECT inventory_types.id FROM inventory_types LEFT JOIN market_groups ON market_groups.id = inventory_types.market_group_id ' +
+		       'GROUP BY inventory_types.name' +
+		       ')'
 	}
 
-	qry += ' GROUP BY inventory_types.name LIMIT ' + limit + ' OFFSET ' + offset
+	qry += ' LIMIT ' + limit + ' OFFSET ' + offset
 
 	pool.query(qry,function(err,rows) {
 		if (err) { console.log('InventoryTypes.prototype.all');console.log(err);respond('Failed to get all inventory_types') }
@@ -413,7 +423,7 @@ InventoryTypes.prototype.indexCount = function (search,respond) {
 	var qry =
 	'SELECT ' +
 
-	'COUNT(*) ' +
+	'COUNT(DISTINCT inventory_types.name) ' +
 
 	'FROM inventory_types ' +
 	'LEFT JOIN market_groups ON market_groups.id = inventory_types.market_group_id'

--- a/models/InventoryTypes.js
+++ b/models/InventoryTypes.js
@@ -410,7 +410,6 @@ InventoryTypes.prototype.index = function (search,page,limit,respond) {
 	}
 
 	qry += ' LIMIT ' + limit + ' OFFSET ' + offset
-  console.log(qry)
 
 	pool.query(qry,function(err,rows) {
 		if (err) { console.log('InventoryTypes.prototype.all');console.log(err);respond('Failed to get all inventory_types') }
@@ -432,7 +431,6 @@ InventoryTypes.prototype.indexCount = function (search,respond) {
 	if (search) {
 		qry += ' WHERE (inventory_types.name LIKE "%'+search+'%" OR market_groups.name LIKE "%'+search+'%")'
 	}
-  console.log(qry)
 
 	pool.query(qry,function(err,rows) {
 		if (err) { console.log('InventoryTypes.prototype.all');console.log(err);respond('Failed to get all inventory_types') }

--- a/models/MarketGroups.js
+++ b/models/MarketGroups.js
@@ -148,7 +148,7 @@ MarketGroups.prototype.index = function (search,page,limit,respond) {
 		qry += ' WHERE (market_groups.name LIKE "%'+search+'%")'
 	}
 
-	qry += ' GROUP BY market_groups.name LIMIT ' + limit + ' OFFSET ' + offset
+	qry += ' LIMIT ' + limit + ' OFFSET ' + offset
 
 	pool.query(qry,function(err,rows) {
 		if (err) { console.log('MarketGroups.prototype.all');console.log(err);respond('Failed to get all market_groups') }


### PR DESCRIPTION
The default settings of a mysql 5.7 installation is a lot stricter about sql. Specifically the sql_modes ONLY_FULL_GROUP_BY, STRICT_TRANS_TABLES, and NO_ZERO_DATE are causing some issue with some of your sql (and those are the defaults now).

These should address most of the problems and functionality should still be identical.